### PR TITLE
Adding missing gem required by rex

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,7 @@ GEM
     ref (2.0.0)
     request_store (1.3.0)
     rex (2.0.9)
+    rkelly-remix (0.0.7)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)


### PR DESCRIPTION
I am not sure if this is issue for warvox or rex not having rkelly-remix as a dependency but since commit 14ae287 bumped the rex version to 2.0.9 it has failed to run and gives a error regarding rkelly.

```
[*] Starting WarVOX on http://127.0.0.1:7777/

[2016-03-03T22:02:02.286739 #12]  INFO -- : WarVOX is starting up...
[2016-03-03T22:02:02.287438 #12]  INFO -- : Worker Manager has PID 14
[2016-03-03T22:02:02.287518 #12]  INFO -- : Web Server has PID 14
/var/lib/gems/2.1.0/gems/rex-2.0.9/lib/rex/proto/http/response.rb:5:in > `require'/var/lib/gems/2.1.0/gems/rex-2.0.9/lib/rex/proto/http/response.rb:5:in `require': : cannot load such file -- rkelly cannot load such file -- rkelly ( (LoadErrorLoadError)
```

It looks like due to a update to the [Rex gem](https://github.com/rapid7/rex/commit/12cdd786a68f2642e69a566d488fd1db812af8ca) it now requires rkelly-remix.

Dockerfile with the fix can be found [Here](https://hub.docker.com/r/beardyjay/warvox/~/dockerfile/) using rkelly-remix 0.0.7 if needed. 